### PR TITLE
Improve file format detection

### DIFF
--- a/CADD.sh
+++ b/CADD.sh
@@ -43,9 +43,9 @@ set -ueo pipefail
 ### Configuring all the paths
 
 FILENAME=$(basename $INFILE)
-NAME=${FILENAME/\.vc*/}
+NAME=${FILENAME%\.vcf*}
 FILEDIR=$(dirname $INFILE)
-FILEFORMAT=${FILENAME/$NAME\./}
+FILEFORMAT=${FILENAME#$NAME\.}
 
 SCRIPT=$(readlink -f "$0")
 export CADD=$(dirname "$SCRIPT")


### PR DESCRIPTION
Fixes #3

Currently does not detect the file format correctly if the input VCF filename is something like `samplename.vcf_altered.vcf.gz` where ".vcf" occurs multiple times.

This change fixes that by using substring removal instead of substring replacement to trim the extension from the filename. This has the advantage of being able to specify that the shortest match of ".vcf*" be removed, so additional ".vcf"s in the filename won't be affected. Technically the change to the `FILEFORMAT=` line isn't necessary, but I changed it just to be consistent with using substring removal instead of replacement.