### PR TITLE
Use mktemp -d for creating temporary directories

### DIFF
--- a/CADD.sh
+++ b/CADD.sh
@@ -104,8 +104,12 @@ then
     DBVERSION=95
 fi
 
+# Setup temporary folder that is removed reliably on exit and is outside of
+# the CADD-scripts directory.
+TMP_FOLDER=$(mktemp -d)
+trap "rm -rf $TMP_FOLDER" ERR EXIT
+
 # Temp files
-TMP_FOLDER=$CADD/data/tmp
 TMP_PRE=$TMP_FOLDER/$NAME.pre.tsv.gz
 TMP_VCF=$TMP_FOLDER/$NAME.vcf
 TMP_ANNO=$TMP_FOLDER/$NAME.anno.tsv.gz


### PR DESCRIPTION
This allows to execute cadd-scripts even if the directory is read-only (such as one might do in a server deployment).

By the way, would it be possible to create version tags for CADD-scripts?