### PR TITLE
PR for mmsplice bump with 2.0.4 and removed dependency to concise.encode 

### DIFF
--- a/envs/mmsplice.yml
+++ b/envs/mmsplice.yml
@@ -6,19 +6,17 @@ channels:
   - defaults
 dependencies:
   - python
-  - cython=0.29.13
-  - pyranges=0.0.51
-  - libgcc=7.2.0
+  - cython
+  - libgcc
+  - keras
   - tensorflow
-  - keras=2.2.4
-  - numpy=1.16.1
-  - scikit-learn
-  - cyvcf2=0.8.4
-  - pandas<0.25.0
+  - numpy
+  - pandas
   - pysam
   - htslib
   - pip
   - pip:
-      - kipoiseq==0.2.5
-      - git+https://github.com/Aerval/SpliceAI.git
-      - mmsplice==1.0.1
+      - mmsplice
+      - cyvcf2
+      - pyranges
+      - kipoiseq

--- a/envs/mmsplice.yml
+++ b/envs/mmsplice.yml
@@ -8,8 +8,6 @@ dependencies:
   - python
   - cython
   - libgcc
-  - keras
-  - tensorflow
   - numpy
   - pandas
   - pysam

--- a/src/scripts/lib/tools/MMSplice.py
+++ b/src/scripts/lib/tools/MMSplice.py
@@ -4,10 +4,7 @@
 from tqdm import tqdm
 # from concise.preprocessing import encodeDNA
 from mmsplice.vcf_dataloader import SplicingVCFDataloader
-from mmsplice import MMSplice
-from mmsplice.utils import logit, predict_deltaLogitPsi, \
-    predict_pathogenicity, predict_splicing_efficiency, \
-    encodeDNA
+from mmsplice import MMSplice, predict_all_table
 import pandas as pd
 import numpy as np
 
@@ -27,100 +24,6 @@ def max_geneEff(df):
     df_max = df_max.merge(df, how='left', on=['ID', 'gene_name', 'delta_logit_psi'])
     df_max = df_max.drop_duplicates(subset=['ID', 'gene_name', 'delta_logit_psi'])
     return df_max
-
-def predict_batch_fast(model, dataloader, batch_size=512, progress=True,
-                       splicing_efficiency=False):
-    """
-    Return the prediction as a table
-    Args:
-      model: mmsplice model object.
-      dataloader: dataloader object.
-      progress: show progress bar.
-      splicing_efficiency: adds splicing_efficiency prediction as column
-    Returns:
-      iterator of pd.DataFrame of modular prediction, delta_logit_psi,
-        splicing_efficiency, pathogenicity.
-    """
-    dataloader.encode = False
-    dt_iter = dataloader.batch_iter(batch_size=batch_size)
-    if progress:
-        dt_iter = tqdm(dt_iter)
-
-    ref_cols = ['ref_acceptorIntron', 'ref_acceptor',
-                'ref_exon', 'ref_donor', 'ref_donorIntron']
-    alt_cols = ['alt_acceptorIntron', 'alt_acceptor',
-                'alt_exon', 'alt_donor', 'alt_donorIntron']
-
-    cat_list = ['acceptor_intron', 'acceptor', 'exon', 'donor', 'donor_intron']
-    cats = {'acceptor_intron': lambda x: model.acceptor_intronM.predict(x),
-            'acceptor': lambda x: logit(model.acceptorM.predict(x)),
-            'exon': lambda x: model.exonM.predict(x),
-            'donor': lambda x: logit(model.donorM.predict(x)),
-            'donor_intron': lambda x: model.donor_intronM.predict(x)}
-
-    for batch in dt_iter:
-        refs,alts = {},{}
-        for cat, model_eval in cats.items():
-            alterations = batch['inputs']['seq'][cat] != \
-                          batch['inputs']['mut_seq'][cat]
-            if np.any(alterations):
-                sequences = list(set([str(s) for s in list(batch['inputs']['seq'][cat][alterations]) + \
-                      list(batch['inputs']['mut_seq'][cat][alterations])]))
-                prediction = model_eval(encodeDNA(sequences)).flatten()
-                pred_dict = {s: p for s, p in zip(sequences, prediction)}
-
-                refs[cat] = [pred_dict[batch['inputs']['seq'][cat][i]] \
-                            if a else 0 for i, a in enumerate(alterations)]
-                alts[cat] = [pred_dict[batch['inputs']['mut_seq'][cat][i]] \
-                            if a else 0 for i, a in enumerate(alterations)]
-            else:
-                refs[cat] = [0] * len(alterations)
-                alts[cat] = [0] * len(alterations)
-        X_ref = np.array([refs[cat] for cat in cat_list]).T
-        X_alt = np.array([alts[cat] for cat in cat_list]).T
-        ref_pred = pd.DataFrame(X_ref, columns=ref_cols)
-        alt_pred = pd.DataFrame(X_alt, columns=alt_cols)
-
-        df = pd.DataFrame({
-            'ID': batch['metadata']['variant']['STR'],
-            'exons': batch['metadata']['exon']['annotation'],
-        })
-        for k in ['exon_id', 'gene_id', 'gene_name', 'transcript_id']:
-            if k in batch['metadata']['exon']:
-                df[k] = batch['metadata']['exon'][k]
-
-        df['delta_logit_psi'] = predict_deltaLogitPsi(X_ref, X_alt)
-        df = pd.concat([df, ref_pred, alt_pred], axis=1)
-
-        # pathogenicity does not work
-        #if pathogenicity:
-        #    df['pathogenicity'] = predict_pathogenicity(X_ref, X_alt)
-
-        if splicing_efficiency:
-            df['efficiency'] = predict_splicing_efficiency(X_ref, X_alt)
-
-        yield df
-
-def predict_table_fast(model,
-                      dataloader,
-                      batch_size=512,
-                      progress=True,
-                      pathogenicity=False,
-                      splicing_efficiency=False):
-    """
-    Return the prediction as a table
-    Args:
-      model: mmsplice model object.
-      dataloader: dataloader object.
-      progress: show progress bar.
-      splicing_efficiency: adds  splicing_efficiency prediction as column
-    Returns:
-      pd.DataFrame of modular prediction, delta_logit_psi, splicing_efficiency,
-        pathogenicity.
-    """
-    return pd.concat(predict_batch_fast(model, dataloader, batch_size=batch_size,
-                                   progress=progress,
-                                   splicing_efficiency=splicing_efficiency))
 
 parser = ArgumentParser(description="%prog name")
 parser.add_argument("-o", "--output", dest="output", type=str,
@@ -143,7 +46,7 @@ model = MMSplice()
 
 try:
     # Do prediction
-    predictions = predict_table_fast(model, dl, batch_size=512)
+    predictions = predict_all_table(model, dl, batch_size=512)
 
     # Summerize with maximum effect size
     predictionsMax = max_geneEff(predictions)

--- a/src/scripts/lib/tools/MMSplice.py
+++ b/src/scripts/lib/tools/MMSplice.py
@@ -2,11 +2,12 @@
 
 # Import
 from tqdm import tqdm
-from concise.preprocessing import encodeDNA
+# from concise.preprocessing import encodeDNA
 from mmsplice.vcf_dataloader import SplicingVCFDataloader
 from mmsplice import MMSplice
 from mmsplice.utils import logit, predict_deltaLogitPsi, \
-    predict_pathogenicity, predict_splicing_efficiency
+    predict_pathogenicity, predict_splicing_efficiency, \
+    encodeDNA
 import pandas as pd
 import numpy as np
 


### PR DESCRIPTION
PR for mmsplice bump with 2.0.4 and removed dependency to concise.encode in reference to this [issue](https://github.com/kircherlab/CADD-scripts/issues/54#issue-2130519397). Works smoothly on the local tests. 