### PR TITLE
Small CADD-scripts update

### DIFF
--- a/CADD.sh
+++ b/CADD.sh
@@ -9,7 +9,7 @@ where:
     -v  CADD version (only v1.7 possible with this set of scripts [default: v1.7])
     -a  include annotation in output
         input vcf of vcf.gz file (required)
-    -m  use mamba/conda only (no apptainer/singularity)
+    -m  use conda only (no apptainer/singularity)
     -r  singularity/apptainer arguments, e.g. \"--bind /data/mnt/x --nv\" [default \"\" but will always add \"--bind $TMP_DIR\"]
     -q  print basic information about snakemake run
     -p  print full information about the snakemake run
@@ -23,7 +23,7 @@ export LC_ALL=C
 
 GENOMEBUILD="GRCh38"
 ANNOTATION=false
-MAMBAONLY=false
+CONDAONLY=false
 OUTFILE=""
 VERSION="v1.7"
 SIGNULARITYARGS=""
@@ -45,7 +45,7 @@ while getopts ':ho:g:v:c:amr:qpd' option; do
        ;;
     a) ANNOTATION=true
        ;;
-    m) MAMBAONLY=true
+    m) CONDAONLY=true
        ;;
     r) SIGNULARITYARGS=$OPTARG
        ;;
@@ -136,7 +136,7 @@ TMP_OUTFILE=$TMP_FOLDER/$NAME.tsv.gz
 cp $INFILE $TMP_INFILE
 
 # setup bindings of singularity args
-if [ "$MAMBAONLY" = 'true' ]
+if [ "$CONDAONLY" = 'true' ]
 then
     SIGNULARITYARGS=""
 else

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,29 @@
-FROM condaforge/mambaforge:latest
+FROM condaforge/miniforge3:latest
 LABEL io.github.snakemake.containerized="true"
-LABEL io.github.snakemake.conda_env_hash="cb2c51dd0ad3df620c4914840c5ef6f5570a5ffd8cfd54cec57d2ffef0a76b08"
+LABEL io.github.snakemake.conda_env_hash="2c2e74f6a7392d16830a1aa1a341e3bd0565e62e3bb0bc4932c8008320fbe806"
 
 # Step 1: Retrieve conda environments
 
-RUN mkdir -p /conda-envs/a4fcaaffb623ea8aef412c66280bd623
-COPY envs/environment_minimal.yml /conda-envs/a4fcaaffb623ea8aef412c66280bd623/environment.yaml
+RUN mkdir -p /conda-envs/fe7049a03d989a2faa6d7688f5987d09
+COPY envs/environment_minimal.yml /conda-envs/fe7049a03d989a2faa6d7688f5987d09/environment.yaml
 
 RUN mkdir -p /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9
 COPY envs/esm.yml /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9/environment.yaml
 
-RUN mkdir -p /conda-envs/7f88b844a05ae487b7bb6530b5e6a90c
-COPY envs/mmsplice.yml /conda-envs/7f88b844a05ae487b7bb6530b5e6a90c/environment.yaml
+RUN mkdir -p /conda-envs/27e6f085c62573d05046d5330f07505d
+COPY envs/mmsplice.yml /conda-envs/27e6f085c62573d05046d5330f07505d/environment.yaml
 
-RUN mkdir -p /conda-envs/dfc51ced08aaeb4cbd3dcd509dec0fc5
-COPY envs/regulatorySequence.yml /conda-envs/dfc51ced08aaeb4cbd3dcd509dec0fc5/environment.yaml
+RUN mkdir -p /conda-envs/f675d936396bfaffdd96e0282b787268
+COPY envs/regulatorySequence.yml /conda-envs/f675d936396bfaffdd96e0282b787268/environment.yaml
 
-RUN mkdir -p /conda-envs/89fe1049cc18768b984c476c399b7989
-COPY envs/vep.yml /conda-envs/89fe1049cc18768b984c476c399b7989/environment.yaml
+RUN mkdir -p /conda-envs/0b37582dec236e35970e555dc2c0f0b5
+COPY envs/vep.yml /conda-envs/0b37582dec236e35970e555dc2c0f0b5/environment.yaml
 
 # Step 2: Generate conda environments
 
-RUN mamba env create --prefix /conda-envs/a4fcaaffb623ea8aef412c66280bd623 --file /conda-envs/a4fcaaffb623ea8aef412c66280bd623/environment.yaml && \
-    mamba env create --prefix /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9 --file /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9/environment.yaml && \
-    mamba env create --prefix /conda-envs/7f88b844a05ae487b7bb6530b5e6a90c --file /conda-envs/7f88b844a05ae487b7bb6530b5e6a90c/environment.yaml && \
-    mamba env create --prefix /conda-envs/dfc51ced08aaeb4cbd3dcd509dec0fc5 --file /conda-envs/dfc51ced08aaeb4cbd3dcd509dec0fc5/environment.yaml && \
-    mamba env create --prefix /conda-envs/89fe1049cc18768b984c476c399b7989 --file /conda-envs/89fe1049cc18768b984c476c399b7989/environment.yaml && \
-    mamba clean --all -y
+RUN conda env create --no-default-packages --prefix /conda-envs/fe7049a03d989a2faa6d7688f5987d09 --file /conda-envs/fe7049a03d989a2faa6d7688f5987d09/environment.yaml && \
+    conda env create --no-default-packages --prefix /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9 --file /conda-envs/ef25c8d726aebbe9e0ee64fee6c3caa9/environment.yaml && \
+    conda env create --no-default-packages --prefix /conda-envs/27e6f085c62573d05046d5330f07505d --file /conda-envs/27e6f085c62573d05046d5330f07505d/environment.yaml && \
+    conda env create --no-default-packages --prefix /conda-envs/f675d936396bfaffdd96e0282b787268 --file /conda-envs/f675d936396bfaffdd96e0282b787268/environment.yaml && \
+    conda env create --no-default-packages --prefix /conda-envs/0b37582dec236e35970e555dc2c0f0b5 --file /conda-envs/0b37582dec236e35970e555dc2c0f0b5/environment.yaml && \
+    conda clean --all -y

--- a/README.md
+++ b/README.md
@@ -45,28 +45,24 @@ This section describes how users can setup CADD version 1.7 on their own system.
 
 ### Prerequisite
 
-- conda or mamba
+- conda > 24.7.4
 
-  We recommend to install conda/mamba via [miniforge](https://github.com/conda-forge/miniforge)
+  We recommend to install conda via [miniforge](https://github.com/conda-forge/miniforge)
 
 ```bash
 # For example 
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh
 ```
-- snakemake 8.X (installed via mamba). 
+- snakemake  >=8.25.2  (installed via conda). 
 
 ```bash
-mamba install -c conda-forge -c bioconda 'snakemake=8'
+conda install -c conda-forge -c bioconda 'snakemake=8'
 ```
 
 - apptainer/singularity (optional, but highly recommended for a more stable environment)
 
-*Note1: If you are using an existing conda installation, please make sure it is [a version >=4.4.0](https://github.com/conda/conda/issues/3200). *
-
-*Note2: We are using mamba here. In principle it should also work with conda, in that case add `--conda-frontend conda` to line 318 in install.sh`*
-
-*Note3: The commands are tested with snakemake 8.25.2. This is the minimum snakemake version supported.*
+*Note1: The commands are tested with snakemake 8.25.2. This is the minimum snakemake version supported.*
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mamba install -c conda-forge -c bioconda 'snakemake=8'
 
 *Note2: We are using mamba here. In principle it should also work with conda, in that case add `--conda-frontend conda` to line 318 in install.sh`*
 
-*Note3: The commands are tested with snakemake 8.15.2. Snakemake 7 (>= 7.32.3) might also work but then the commands are different and the `CADD.sh` script will not work.*
+*Note3: The commands are tested with snakemake 8.25.2. This is the minimum snakemake version supported.*
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ There are a few options to decrease calculation times of your CADD offline insta
 
 ### Update
 
+#### Version 1.7.2
+
+Just a `CADD-Script` version update. CADD scores are the same as with CADD-script v1.7 (CADD scores v1.7). Detailed changes:
+
+- only snakemake >= 8.25.2 supported
+- using only conda-forge and bioconda channels (no default anymore)
+- new container `docker://visze/cadd-scripts-v1_7:0.1.1`
+- only conda >24.7.1 is allowed (no mamba support anymore)
+- `VCF2vepVCF.py` script fix to extend header. Otherwise regseq will fail using the vcf library
+- readme update
+
 #### Version 1.7.1
 
 Just a `CADD-Script` version update for snakemake 8 compatibility and containerization. CADD scores are the same as with CADD-script v1.7 (CADD scores v1.7). Detailed changes:

--- a/Snakefile
+++ b/Snakefile
@@ -4,13 +4,13 @@ Note that we are declaring many files temporary here that should be located in a
 
 
 # container with conda environments
-containerized: "docker://visze/cadd-scripts-v1_7:0.1.0"
+containerized: "docker://visze/cadd-scripts-v1_7:0.1.1"
 
 
 # Min version of snakemake
 from snakemake.utils import min_version
 
-min_version("7.32.3")
+min_version("8.25.2")
 
 # Validation of config file
 from snakemake.utils import validate

--- a/envs/environment_minimal.yml
+++ b/envs/environment_minimal.yml
@@ -2,7 +2,7 @@ name: cadd-minimal
 channels:
   - bioconda
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - python=2.7.13=0
   - scikit-learn=0.20.4

--- a/envs/mmsplice.yml
+++ b/envs/mmsplice.yml
@@ -3,6 +3,7 @@ name: mmsplice
 channels:
   - bioconda
   - conda-forge
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu

--- a/envs/regulatorySequence.yml
+++ b/envs/regulatorySequence.yml
@@ -1,8 +1,8 @@
 ---
 channels:
-  - defaults
   - bioconda
   - conda-forge
+  - nodefaults
 dependencies:
   - numpy<=1.23.5
   - click

--- a/envs/vep.yml
+++ b/envs/vep.yml
@@ -3,7 +3,7 @@ name: vep
 channels:
     - conda-forge
     - bioconda
-    - defaults
+    - nodefaults
 dependencies:
     - ensembl-vep=110
     - pyvcf=0.6.*

--- a/src/scripts/VCF2vepVCF.py
+++ b/src/scripts/VCF2vepVCF.py
@@ -91,7 +91,7 @@ for line in sys.stdin:
     line = line.rstrip('\r\n')
     if line.upper().startswith("#CHROM"):
         fields = line.split()
-        outsnvs.write("\t".join(fields[:falt_allele+1])+"\n")
+        outsnvs.write("\t".join(fields[:falt_allele+1])+"\tQUAL\tFILTER\tINFO\n")
         if options.SNVs != None or options.InDels != None:
             outindels.write("\t".join(fields[:falt_allele+1])+"\n")
     if line.startswith("#"):


### PR DESCRIPTION
- only snakemake >= 8.25.2 supported
- using only conda-forge and bioconda channels (no default anymore)
- new container `docker://visze/cadd-scripts-v1_7:0.1.1`
- only conda >24.7.1 is allowed (no mamba support anymore)
- `VCF2vepVCF.py` script fix to extend header. Otherwise regseq will fail using the vcf library
- readme update